### PR TITLE
Update "1.17+ Requires Java 16" with clearer text.

### DIFF
--- a/src/parsers.rs
+++ b/src/parsers.rs
@@ -139,7 +139,7 @@ fn one_seventeen_java_too_new(log: &str) -> Option<(&str, String)> {
         Please install Java 16 you can find downloads [here](https://www.azul.com/downloads/?version=java-16-sts&architecture=x86-64-bit&package=jre#download-openjdk))\n\
         On Windows: Download the .msi file. After installation you may have to update MultiMC to detect the new Java version, to do so open the settings and \
         change Update Channel to 'Development', then update MultiMC.\n\
-        Open the MultiMC Java settings and make sure Java 8 is still selected as default for more help with that run `-sjava`.\
+        Open the MultiMC Java settings and make sure Java 8 is still selected as default for more help with that, send `-sjava` in this channel.\
         Then edit your 1.17 instance settings, open the Java tab, check 'Java Installation', click 'Auto-detect..' and select Java 16.".to_string()))
     } else {
         None


### PR DESCRIPTION
Based on convos in the MultiMC channel on Discord, updating the bot output with a slightly clearer instruction on where to use -sjava. It looks way too much like a Java argument, so some confusion tends to happen. This should fix that.